### PR TITLE
feat: Add Internal Function To Calculate Total Volume

### DIFF
--- a/src/FlashArbitrageV3.sol
+++ b/src/FlashArbitrageV3.sol
@@ -629,4 +629,12 @@ contract ImprovedFlashArbitrageV3 is IFlashLoanRecipient, ReentrancyGuard, Ownab
             emit CircuitBreakerStateChanged(oldState, cb.state, cb.currentVolume, cb.maxVolumePerPeriod);
         }
     }
+
+    function _calculateTotalVolume(uint256[] memory amounts) internal pure returns (uint256) {
+        uint256 total = 0;
+        for (uint i = 0; i < amounts.length; i++) {
+            total += amounts[i];
+        }
+        return total;
+    }
 }

--- a/src/FlashArbitrageV3.sol
+++ b/src/FlashArbitrageV3.sol
@@ -630,6 +630,7 @@ contract ImprovedFlashArbitrageV3 is IFlashLoanRecipient, ReentrancyGuard, Ownab
         }
     }
 
+    /// @notice Calculate total volume from amounts array
     function _calculateTotalVolume(uint256[] memory amounts) internal pure returns (uint256) {
         uint256 total = 0;
         for (uint i = 0; i < amounts.length; i++) {


### PR DESCRIPTION
## Description
This PR adds an internal pure helper function `_calculateTotalVolume` to `ImprovedFlashArbitrageV3`.  
It computes the total trading volume by summing an array of amounts, providing a reusable utility for volume-based logic such as circuit breaker checks.

## Changes Made
- Added `_calculateTotalVolume(uint256[] memory amounts)` internal pure function  
- Implemented loop-based summation of trade amounts  
- Ensures accurate aggregation of volumes with minimal gas overhead  
- Added NatSpec documentation for clarity  

## Type of Change
- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Testing
- [ ] Unit tests added for `_calculateTotalVolume`  
- [ ] Verified correct sum of arrays with multiple values  
- [ ] Checked edge case with empty array (should return 0)  
- [ ] Tested large arrays for overflow safety (relies on Solidity 0.8+ checked arithmetic)  

## Checklist
- [x] My code follows the project's style guidelines  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my feature works as intended  
- [x] New and existing tests pass locally with my changes  

## Related Issues
N/A  

## Security Considerations
- Uses Solidity 0.8+ built-in overflow checks for safe arithmetic  
- Pure function, no state modification or external calls  
- Gas efficient iteration over dynamic arrays  

## Screenshots/Demo (if applicable)
N/A
