### PR TITLE
feat: Add Ability To Validate routes haven't failed recently

### DIFF
--- a/src/FlashArbitrageV3.sol
+++ b/src/FlashArbitrageV3.sol
@@ -644,6 +644,7 @@ contract ImprovedFlashArbitrageV3 is IFlashLoanRecipient, ReentrancyGuard, Ownab
         return (volume * dynamicProfitMultiplier) / MAX_BPS;
     }
 
+    /// @notice Validate routes haven't failed recently
     function _validateRoutes(ArbitrageParamsV3 memory params) internal view {
         bytes32 buyRouteHash = keccak256(abi.encode(params.buyRoute));
         bytes32 sellRouteHash = keccak256(abi.encode(params.sellRoute));

--- a/src/FlashArbitrageV3.sol
+++ b/src/FlashArbitrageV3.sol
@@ -643,4 +643,18 @@ contract ImprovedFlashArbitrageV3 is IFlashLoanRecipient, ReentrancyGuard, Ownab
     function _calculateDynamicMinProfit(uint256 volume) internal view returns (uint256) {
         return (volume * dynamicProfitMultiplier) / MAX_BPS;
     }
+
+    function _validateRoutes(ArbitrageParamsV3 memory params) internal view {
+        bytes32 buyRouteHash = keccak256(abi.encode(params.buyRoute));
+        bytes32 sellRouteHash = keccak256(abi.encode(params.sellRoute));
+        
+        require(
+            failedRoutes[buyRouteHash] == 0 || block.timestamp > failedRoutes[buyRouteHash] + 1 hours,
+            "Buy route recently failed"
+        );
+        require(
+            failedRoutes[sellRouteHash] == 0 || block.timestamp > failedRoutes[sellRouteHash] + 1 hours,
+            "Sell route recently failed"
+        );
+    }
 }


### PR DESCRIPTION
## Description
This PR introduces the `_validateRoutes` internal view function in `ImprovedFlashArbitrageV3`.  
The function ensures that arbitrage routes that recently failed cannot be retried immediately, adding a **cooldown mechanism** to improve trade reliability and reduce wasted gas on failed attempts.

## Changes Made
- Added `_validateRoutes(ArbitrageParamsV3 memory params)` internal view function
- Introduced route validation by hashing `buyRoute` and `sellRoute`:
  - Rejects trades if the route failed within the last **1 hour**
  - Allows retrying once the cooldown has passed
- Added NatSpec documentation for better code maintainability

## Type of Change
- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Testing
- [ ] Added unit tests for `_validateRoutes`  
- [ ] Verified that a route fails if retried within the cooldown period  
- [ ] Verified that a route passes after cooldown expires  
- [ ] Checked that different routes are validated independently  

## Checklist
- [x] Code follows project’s style and conventions  
- [x] Added NatSpec comments  
- [ ] Added tests covering new logic  
- [x] Existing tests pass  

## Related Issues
N/A  

## Security Considerations
- Prevents repeated execution of failing routes within a short time window  
- Reduces risk of MEV bots or spamming failed trades  
- Keeps logic internal (not externally callable), minimizing attack surface  

## Notes
This feature lays groundwork for **route health tracking**, and can later be extended to:  
- Dynamic cooldowns (based on severity of failure)  
- More sophisticated route scoring/blacklisting mechanisms  
