### PR TITLE
feat: Add _calculateVolatilityIndex Internal View Function

### DIFF
--- a/src/FlashArbitrageV3.sol
+++ b/src/FlashArbitrageV3.sol
@@ -658,4 +658,10 @@ contract ImprovedFlashArbitrageV3 is IFlashLoanRecipient, ReentrancyGuard, Ownab
             "Sell route recently failed"
         );
     }
+
+    function _calculateVolatilityIndex() internal view returns (uint256) {
+        // Simplified volatility calculation
+        // In production, this would analyze price feed data and historical trades
+        return (stats.totalTrades * 100) / (block.timestamp - stats.lastTradeTimestamp + 1);
+    }
 }

--- a/src/FlashArbitrageV3.sol
+++ b/src/FlashArbitrageV3.sol
@@ -659,6 +659,7 @@ contract ImprovedFlashArbitrageV3 is IFlashLoanRecipient, ReentrancyGuard, Ownab
         );
     }
 
+    /// @notice Calculate market volatility index
     function _calculateVolatilityIndex() internal view returns (uint256) {
         // Simplified volatility calculation
         // In production, this would analyze price feed data and historical trades


### PR DESCRIPTION
## Description
This PR introduces the `_calculateVolatilityIndex` internal view function to the `ImprovedFlashArbitrageV3` contract.  
The function provides a simplified mechanism to estimate market volatility for arbitrage strategies.

## Changes Made
- Added `_calculateVolatilityIndex()` function:
  - **Type**: `internal view`
  - **Logic**: Calculates a basic volatility index using trade count relative to elapsed time.
  - **Fallback Handling**: Avoids division by zero by adding `+1` to denominator.
- Added Natspec documentation for improved clarity and maintainability.

## Type of Change
- [ ] Bug fix  
- [ ] Documentation update  
- [x] New feature  
- [ ] Breaking change  

## Checklist
- [x] Function compiles successfully  
- [x] Integrated with existing contract structure  
- [x] Clear Natspec comments for future reference  

## Impact
This function allows for **volatility awareness** within the arbitrage system, paving the way for future dynamic risk controls and strategy adjustments based on market conditions.

## Related Issues
N/A
