### PR TITLE
feat: Add Help Command and Development Environment Setup to Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -76,3 +76,7 @@ help: ## Display this help message
 	@echo "  Solidity: $(MAGENTA)$(SOLIDITY_VERSION)$(RESET)"
 	@echo "  Profile: $(MAGENTA)$(FOUNDRY_PROFILE)$(RESET)"
 	@echo ""
+
+# ================================================================
+# DEVELOPMENT ENVIRONMENT
+# ================================================================

--- a/makefile
+++ b/makefile
@@ -62,3 +62,17 @@ RESET := \033[0m
 
 .DEFAULT_GOAL := help
 .PHONY: help
+
+help: ## Display this help message
+	@echo "$(CYAN)===============================================$(RESET)"
+	@echo "$(CYAN)  Flash Arbitrage V3 - Development Makefile  $(RESET)"
+	@echo "$(CYAN)===============================================$(RESET)"
+	@echo ""
+	@echo "$(YELLOW)📋 Available Commands:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(GREEN)%-20s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "$(YELLOW)🔧 Configuration:$(RESET)"
+	@echo "  Project: $(MAGENTA)$(PROJECT_NAME)$(RESET) v$(MAGENTA)$(VERSION)$(RESET)"
+	@echo "  Solidity: $(MAGENTA)$(SOLIDITY_VERSION)$(RESET)"
+	@echo "  Profile: $(MAGENTA)$(FOUNDRY_PROFILE)$(RESET)"
+	@echo ""

--- a/makefile
+++ b/makefile
@@ -80,3 +80,12 @@ help: ## Display this help message
 # ================================================================
 # DEVELOPMENT ENVIRONMENT
 # ================================================================
+
+install: ## Install dependencies and initialize project
+	@echo "$(BLUE)🔧 Installing Foundry dependencies...$(RESET)"
+	forge install foundry-rs/forge-std
+	forge install OpenZeppelin/openzeppelin-contracts
+	forge install balancer-labs/v2-interfaces
+	forge install Uniswap/v3-periphery
+	forge install smartcontractkit/chainlink
+	@echo "$(GREEN)✅ Dependencies installed successfully$(RESET)"


### PR DESCRIPTION
# PR Description
## Summary
This PR enhances the Makefile for **Flash Arbitrage V3** by introducing a developer-friendly help system and setup automation for the development environment.

## Changes
- Added `help` target to display all available commands with color-coded formatting for better readability.
- Added Natspec-style section header for **Development Environment**.
- Introduced `install` target to install and initialize project dependencies:
  - Foundry standard library (`forge-std`)
  - OpenZeppelin Contracts
  - Balancer v2 Interfaces
  - Uniswap v3 Periphery
  - Chainlink

## Motivation
These changes improve the **developer experience** by:
- Making the Makefile self-documenting via the `help` command.
- Streamlining environment setup with a single `make install` command.
- Establishing clear organizational structure through section headers.

## Notes
- The `help` target automatically parses descriptions (`##`) from Makefile targets.
- Future contributors can easily extend the Makefile following this format.
