### PR TITLE
feat: Add update target to makefile for dependencies

### DIFF
--- a/makefile
+++ b/makefile
@@ -89,3 +89,8 @@ install: ## Install dependencies and initialize project
 	forge install Uniswap/v3-periphery
 	forge install smartcontractkit/chainlink
 	@echo "$(GREEN)✅ Dependencies installed successfully$(RESET)"
+
+update: ## Update all dependencies to latest versions
+	@echo "$(BLUE)🔄 Updating dependencies...$(RESET)"
+	forge update
+	@echo "$(GREEN)✅ Dependencies updated$(RESET)"


### PR DESCRIPTION
# PR Description
## Summary
This PR introduces an `update` target in the project Makefile to simplify dependency maintenance.

## Changes
- Added `update` target with the following steps:
  - Prints update status to console.
  - Runs `forge update` to fetch the latest versions of all dependencies.
  - Confirms completion with a success message.

## Motivation
Maintaining up-to-date dependencies ensures:
- Security patches are applied promptly.
- Compatibility with the latest tooling and libraries.
- Reduced technical debt and easier long-term project maintenance.

## Usage
Run the following command to update dependencies:
```bash
make update