### PR TITLE
feat: add deployment scripts for local and testnet environments

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,17 @@
+{
+  "lib/balancer-v2-monorepo": {
+    "rev": "36d282374b457dddea828be7884ee0d185db06ba"
+  },
+  "lib/forge-std": {
+    "rev": "b93cf4bc34ff214c099dc970b153f85ade8c9f66"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "281550b71c3df9a83e6b80ceefc700852c287570"
+  },
+  "lib/v3-core": {
+    "rev": "e3589b192d0be27e100cd0daaf6c97204fdb1899"
+  },
+  "lib/v3-periphery": {
+    "rev": "80f26c86c57b8a5e4b913f42844d4c8bd274d058"
+  }
+}

--- a/makefile
+++ b/makefile
@@ -208,3 +208,11 @@ deploy-sepolia: ## Deploy to Sepolia testnet
 		--etherscan-api-key $(ETHERSCAN_API_KEY) \
 		--gas-limit $(GAS_LIMIT) \
 		--gas-price $(GAS_PRICE)
+
+deploy-goerli: ## Deploy to Goerli testnet
+	@echo "$(BLUE)🚀 Deploying to Goerli...$(RESET)"
+	forge script script/Deploy.s.sol:DeployScript \
+		--rpc-url $(GOERLI_RPC_URL) \
+		--broadcast \
+		--verify \
+		--etherscan-api-key $(ETHERSCAN_API_KEY)

--- a/makefile
+++ b/makefile
@@ -192,3 +192,8 @@ audit-prep: fmt build analyze ## Prepare for security audit
 # ================================================================
 # DEPLOYMENT SCRIPTS
 # ================================================================
+
+# Local deployment
+deploy-local: ## Deploy to local anvil network
+	@echo "$(BLUE)🚀 Deploying to local network...$(RESET)"
+	forge script script/Deploy.s.sol:DeployScript --rpc-url http://localhost:8545 --broadcast

--- a/makefile
+++ b/makefile
@@ -197,3 +197,14 @@ audit-prep: fmt build analyze ## Prepare for security audit
 deploy-local: ## Deploy to local anvil network
 	@echo "$(BLUE)🚀 Deploying to local network...$(RESET)"
 	forge script script/Deploy.s.sol:DeployScript --rpc-url http://localhost:8545 --broadcast
+
+# Testnet deployments
+deploy-sepolia: ## Deploy to Sepolia testnet
+	@echo "$(BLUE)🚀 Deploying to Sepolia...$(RESET)"
+	forge script script/Deploy.s.sol:DeployScript \
+		--rpc-url $(SEPOLIA_RPC_URL) \
+		--broadcast \
+		--verify \
+		--etherscan-api-key $(ETHERSCAN_API_KEY) \
+		--gas-limit $(GAS_LIMIT) \
+		--gas-price $(GAS_PRICE)

--- a/makefile
+++ b/makefile
@@ -188,3 +188,7 @@ mythril: ## Run mythril security analysis
 	myth analyze src/ImprovedFlashArbitrageV3.sol
 
 audit-prep: fmt build analyze ## Prepare for security audit
+
+# ================================================================
+# DEPLOYMENT SCRIPTS
+# ================================================================


### PR DESCRIPTION
# Pull Request
## Summary
This PR introduces deployment automation via `makefile` targets and updates dependencies through `foundry.lock`. It provides a streamlined way to deploy contracts locally or on supported Ethereum testnets.

## Changes
- **Deployment Scripts**
  - Added section header for deployment scripts in `makefile`.
  - Added `deploy-local` target:
    - Deploys to a local Anvil network.
  - Added `deploy-sepolia` target:
    - Deploys to the Sepolia testnet.
    - Includes Etherscan verification, gas config, and API key integration.
  - Added `deploy-goerli` target:
    - Deploys to the Goerli testnet.
    - Includes Etherscan verification and API key integration.
- **Dependencies**
  - Added `foundry.lock` file to pin dependency versions:
    - `balancer-v2-monorepo`
    - `forge-std`
    - `openzeppelin-contracts`
    - `v3-core`
    - `v3-periphery`

## Motivation
- Simplifies developer workflows by allowing quick deployments with a single command.
- Ensures consistency between environments (local, Sepolia, Goerli).
- Locks dependencies to guarantee reproducible builds.

## Next Steps
- Add deployment targets for **mainnet** and **additional testnets** (e.g., Holesky).
- Implement environment-based configuration (e.g., `.env` integration for secrets).
- Create CI/CD pipeline integration for automated testnet deployments.
