### PR TITLE
feat: add documentation generation and local serve support

### DIFF
--- a/makefile
+++ b/makefile
@@ -294,3 +294,9 @@ anvil-polygon: ## Start Anvil forked from Polygon
 # ================================================================
 # DOCUMENTATION
 # ================================================================
+
+docs: ## Generate documentation
+	@echo "$(BLUE)📚 Generating documentation...$(RESET)"
+	mkdir -p $(DOCS_DIR)
+	forge doc --build --out $(DOCS_DIR)
+	@echo "$(GREEN)✅ Documentation generated at $(DOCS_DIR)$(RESET)"

--- a/makefile
+++ b/makefile
@@ -300,3 +300,7 @@ docs: ## Generate documentation
 	mkdir -p $(DOCS_DIR)
 	forge doc --build --out $(DOCS_DIR)
 	@echo "$(GREEN)✅ Documentation generated at $(DOCS_DIR)$(RESET)"
+
+docs-serve: docs ## Serve documentation locally
+	@echo "$(BLUE)🌐 Serving documentation at http://localhost:3000$(RESET)"
+	forge doc --serve --port 3000

--- a/makefile
+++ b/makefile
@@ -290,3 +290,7 @@ anvil-fork: ## Start Anvil forked from mainnet
 anvil-polygon: ## Start Anvil forked from Polygon
 	@echo "$(BLUE)🍴 Starting Anvil forked from Polygon...$(RESET)"
 	anvil --fork-url $(POLYGON_RPC_URL) --host 0.0.0.0 --port 8545
+
+# ================================================================
+# DOCUMENTATION
+# ================================================================


### PR DESCRIPTION
# Pull Request
## Summary
This PR introduces a new **documentation workflow** powered by Forge, including commands to generate and serve project documentation locally.

## Changes
- Added **NatSpec header section** for improved documentation organization.
- Updated `Makefile` with:
  - `docs` → generates documentation into the `$(DOCS_DIR)` directory using `forge doc`.
  - `docs-serve` → serves the generated documentation locally at `http://localhost:3000`.
- Added console output for better DX when generating/serving docs.

## Motivation
- Streamline developer experience by making it easier to:
  - Generate contract documentation from NatSpec comments.
  - Preview documentation locally during development.
- Improves overall clarity and maintainability of the codebase.

## Next Steps
- Configure CI pipeline to auto-generate and publish docs.  
- Expand NatSpec coverage across all contracts for richer documentation.  
