### PR TITLE
feat: add CI/CD makefile targets for testing and coverage

### DIFF
--- a/makefile
+++ b/makefile
@@ -344,3 +344,7 @@ env-check: ## Check environment variables
 	@echo "ALCHEMY_API_KEY: $(if $(ALCHEMY_API_KEY),$(GREEN)✅ Set$(RESET),$(RED)❌ Missing$(RESET))"
 	@echo "ETHERSCAN_API_KEY: $(if $(ETHERSCAN_API_KEY),$(GREEN)✅ Set$(RESET),$(RED)❌ Missing$(RESET))"
 	@echo "PRIVATE_KEY: $(if $(PRIVATE_KEY),$(GREEN)✅ Set$(RESET),$(RED)❌ Missing$(RESET))"
+
+# ================================================================
+# CI/CD TARGETS
+# ================================================================

--- a/makefile
+++ b/makefile
@@ -352,3 +352,7 @@ env-check: ## Check environment variables
 ci-test: ## Run tests in CI environment
 	@echo "$(BLUE)🤖 Running CI tests...$(RESET)"
 	forge test --no-match-path "test/fork/*"
+
+ci-coverage: ## Generate coverage in CI
+	@echo "$(BLUE)🤖 Generating CI coverage...$(RESET)"
+	forge coverage --report summary

--- a/makefile
+++ b/makefile
@@ -348,3 +348,7 @@ env-check: ## Check environment variables
 # ================================================================
 # CI/CD TARGETS
 # ================================================================
+
+ci-test: ## Run tests in CI environment
+	@echo "$(BLUE)🤖 Running CI tests...$(RESET)"
+	forge test --no-match-path "test/fork/*"


### PR DESCRIPTION
## Summary
This PR introduces **CI/CD automation targets** in the Makefile to streamline testing and coverage reporting in continuous integration environments.

---

## Changes
### `makefile`
- Added **CI/CD section** with new targets:
  - `ci-test` → runs tests in CI environment (skips fork tests)  
  - `ci-coverage` → generates a summarized coverage report for CI  

- Structured with a dedicated **CI/CD section header** for clarity  

---

## Benefits
- Enables consistent **automated testing** in CI pipelines  
- Provides **coverage insights** directly in CI output  
- Improves maintainability by centralizing developer and CI commands in the Makefile  

---

## Next Steps
- Integrate these targets into GitHub Actions / CI pipeline  
- Add artifacts upload step for full coverage reports if needed  
- Expand with gas reporting or lint checks for CI  
