### PR TITLE
feat: add emergency pause command to Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -395,3 +395,7 @@ full-check: fmt build test-coverage gas-snapshot analyze ## Complete code qualit
 # ================================================================
 # EMERGENCY COMMANDS
 # ================================================================
+
+emergency-pause: ## Emergency pause contract (requires CONTRACT_ADDRESS)
+	@echo "$(RED)🚨 EMERGENCY PAUSE$(RESET)"
+	cast send $(CONTRACT_ADDRESS) "pause()" --rpc-url $(MAINNET_RPC_URL) --private-key $(PRIVATE_KEY)

--- a/makefile
+++ b/makefile
@@ -391,3 +391,7 @@ quick-test: build test-unit ## Quick test cycle
 deploy-test: deploy-sepolia interact-testnet ## Deploy and test on testnet
 
 full-check: fmt build test-coverage gas-snapshot analyze ## Complete code quality check
+
+# ================================================================
+# EMERGENCY COMMANDS
+# ================================================================


### PR DESCRIPTION
# PR Description
## Summary
This PR introduces an **Emergency Commands** section to the project’s `Makefile`, allowing maintainers to quickly respond to critical situations by pausing a deployed contract on mainnet.

## Changes
- **Makefile**
  - Added **Natspec-style section header** for emergency commands.
  - Implemented `emergency-pause` target:
    - Sends a transaction to the deployed contract’s `pause()` function.  
    - Requires `CONTRACT_ADDRESS` to be set.  
    - Uses `MAINNET_RPC_URL` and `PRIVATE_KEY` for execution.  
    - Includes a 🚨 console warning message for visibility.

## Impact
- Provides maintainers with a fast, automated way to pause contracts during emergencies.
- Reduces the risk of manual mistakes by centralizing the emergency procedure.
- Improves operational safety by making critical commands easily discoverable and executable.

## Next Steps
- Add an `emergency-unpause` command for recovery.  
- Extend emergency tooling to support multiple networks (e.g., Polygon, Optimism).  
- Consider role-based access safeguards when integrating with production workflows.
