### PR TITLE
feat: add emergency unpause and withdraw makefile targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -403,3 +403,8 @@ emergency-pause: ## Emergency pause contract (requires CONTRACT_ADDRESS)
 emergency-unpause: ## Emergency unpause contract
 	@echo "$(YELLOW)⚠️ Unpausing contract$(RESET)"
 	cast send $(CONTRACT_ADDRESS) "unpause()" --rpc-url $(MAINNET_RPC_URL) --private-key $(PRIVATE_KEY)
+
+emergency-withdraw: ## Emergency withdraw (requires EMERGENCY_TOKEN)
+	@echo "$(RED)🚨 EMERGENCY WITHDRAWAL$(RESET)"
+	cast send $(CONTRACT_ADDRESS) "emergencyWithdraw(address,uint256)" $(EMERGENCY_TOKEN) 0 \
+		--rpc-url $(MAINNET_RPC_URL) --private-key $(PRIVATE_KEY)

--- a/makefile
+++ b/makefile
@@ -399,3 +399,7 @@ full-check: fmt build test-coverage gas-snapshot analyze ## Complete code qualit
 emergency-pause: ## Emergency pause contract (requires CONTRACT_ADDRESS)
 	@echo "$(RED)🚨 EMERGENCY PAUSE$(RESET)"
 	cast send $(CONTRACT_ADDRESS) "pause()" --rpc-url $(MAINNET_RPC_URL) --private-key $(PRIVATE_KEY)
+
+emergency-unpause: ## Emergency unpause contract
+	@echo "$(YELLOW)⚠️ Unpausing contract$(RESET)"
+	cast send $(CONTRACT_ADDRESS) "unpause()" --rpc-url $(MAINNET_RPC_URL) --private-key $(PRIVATE_KEY)


### PR DESCRIPTION
## Summary
This PR extends the Makefile with additional **emergency management shortcuts** for interacting with the deployed contract.  
These commands enhance the existing `emergency-pause` functionality by enabling **contract unpause** and **emergency withdrawal** execution.

---

## Changes
### `makefile`
- Added `emergency-unpause`:
  - Unpauses the contract if previously paused
  - Uses `cast send` with `unpause()` call
  - Prints a clear ⚠️ warning message before execution
- Added `emergency-withdraw`:
  - Executes `emergencyWithdraw(address,uint256)` on the contract
  - Requires the `EMERGENCY_TOKEN` environment variable
  - Emits a 🚨 warning for visibility
- Both targets leverage `MAINNET_RPC_URL` and `PRIVATE_KEY` for secure execution

---

## Benefits
- Improves **incident response** during emergencies:
  - `emergency-unpause` allows safe contract resumption
  - `emergency-withdraw` provides a mechanism to safeguard funds
- Provides **clear CLI feedback** with colored messages (🚨 / ⚠️ indicators)
- Consistent structure with existing `emergency-pause` target

---

## Next Steps
- Add testnet equivalents (`emergency-unpause-testnet`, `emergency-withdraw-testnet`) for safer dry-runs
- Consider role-based access checks to ensure only authorized operators execute these actions
- Integrate with CI/CD for controlled emergency ops

---

## Notes
This PR completes the **emergency response toolkit** in the Makefile, ensuring that critical pause, unpause, and withdrawal operations are easily accessible to operators during urgent scenarios.
