### PR TITLE
feat(arbitrage): Add `TradeFailed` event with detailed failure diagnostics

### DIFF
--- a/src/onchain/TestArbitrage.sol
+++ b/src/onchain/TestArbitrage.sol
@@ -180,6 +180,11 @@ contract TestArbitrage is IFlashLoanRecipient, ReentrancyGuard, Ownable, Pausabl
     /// @param executionTime Time taken for execution (in seconds)
     event TradeCompleted(uint256 indexed tradeId, uint256 profit, uint256 gasUsed, uint256 executionTime);
 
+    /// @notice Emitted when a trade fails with detailed error information
+    /// @param tradeId Unique identifier for this trade
+    /// @param reason Error message describing the failure
+    /// @param step Which step of the process failed (1=first swap, 2=second swap, 3=repayment)
+    /// @param gasUsed Gas consumed before failure
     event TradeFailed(uint256 indexed tradeId, string reason, uint8 step, uint256 gasUsed);
 
     /// @notice Emitted when contract configuration is updated

--- a/src/onchain/TestArbitrage.sol
+++ b/src/onchain/TestArbitrage.sol
@@ -180,6 +180,8 @@ contract TestArbitrage is IFlashLoanRecipient, ReentrancyGuard, Ownable, Pausabl
     /// @param executionTime Time taken for execution (in seconds)
     event TradeCompleted(uint256 indexed tradeId, uint256 profit, uint256 gasUsed, uint256 executionTime);
 
+    event TradeFailed(uint256 indexed tradeId, string reason, uint8 step, uint256 gasUsed);
+
     /// @notice Emitted when contract configuration is updated
     /// @param parameter Name of the parameter changed
     /// @param oldValue Previous value


### PR DESCRIPTION
# Description

This PR enhances observability and debugging capabilities within `TestArbitrage` by introducing a new `TradeFailed` event. This complements existing trade lifecycle events (`TradeInitiated`, `TradeCompleted`) by explicitly surfacing failure scenarios with structured context.

---

## ✅ What’s New

### 🛑 `TradeFailed` Event Added

A fully Natspec-documented event that captures granular failure insights:

```solidity
/// @notice Emitted when a trade fails with detailed error information
/// @param tradeId Unique identifier for this trade
/// @param reason Error message describing the failure
/// @param step Which step of the process failed (1=first swap, 2=second swap, 3=repayment)
/// @param gasUsed Gas consumed before failure
event TradeFailed(uint256 indexed tradeId, string reason, uint8 step, uint256 gasUsed);
